### PR TITLE
updated z-index for section labels

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -14,7 +14,7 @@
   position: absolute;
   margin: -20px 4px;
   padding: 0 4px;
-  z-index: 9;
+  z-index: 2;
   font-size: 1.15em;
 }
 

--- a/sidebar.css
+++ b/sidebar.css
@@ -13,7 +13,7 @@
     position: absolute;
     margin: -12px 12px;
     padding: 0 4px;
-    z-index: 9;
+    z-index: 2;
     font-size: 1.15em;
   }
 }


### PR DESCRIPTION
This stops them from drawing over the search suggestions.

I played around with trying to center the search suggestions as well for a more streamlined experience, but didn't have much luck. Might try that later.

Love the theme, by the way.