### PR TITLE
fix: contain all navbar elements inside border

### DIFF
--- a/navbar.css
+++ b/navbar.css
@@ -38,7 +38,6 @@
 }
 
 #nav-bar {
-  background-color: transparent !important;
   border-top: var(--border-width) !important;
 }
 
@@ -51,7 +50,6 @@
   border-color: var(--border) !important;
   border-radius: var(--rounding);
   transition: border-color var(--border-transition) !important;
-  background-color: transparent !important;
   &::before {
     content: "navbar";
     background-color: var(--bg);
@@ -82,4 +80,10 @@
   --tab-min-height: fit-content !important;
   min-height: fit-content !important;
   padding-top: 3px !important;
+}
+
+.browser-toolbar {
+  &:not(.titlebar-color) {
+  background-color: transparent !important;
+  }
 }

--- a/navbar.css
+++ b/navbar.css
@@ -39,31 +39,31 @@
 
 #nav-bar {
   background-color: transparent !important;
+  border-top: var(--border-width) !important;
+}
+
+#navigator-toolbox {
   margin: 8px;
   padding: 4px !important;
-  border-top: var(--border-width) !important;
+  border-bottom: var(--border-width)!important;
   border-style: solid !important;
   border-width: var(--border-width);
   border-color: var(--border) !important;
   border-radius: var(--rounding);
-  transition: border-color var(--border-transition);
-  &:hover,
-  &:focus {
-    border-color: var(--accent) !important;
-  }
-}
-
-#navigator-toolbox {
-  border-bottom: unset !important;
+  transition: border-color var(--border-transition) !important;
   background-color: transparent !important;
   &::before {
     content: "navbar";
     background-color: var(--bg);
     position: absolute;
-    margin: 0 22px;
+    margin: -16px 8px;
     padding: 0 2px;
     z-index: 2;
     font-size: 1.15em;
+  }
+  &:hover,
+  &:focus {
+    border-color: var(--accent) !important;
   }
   &:hover::before {
     color: var(--accent);
@@ -78,3 +78,8 @@
   text-align: center;
 }
 
+:root[tabsintitlebar] #toolbar-menubar[autohide="true"] {
+  --tab-min-height: fit-content !important;
+  min-height: fit-content !important;
+  padding-top: 3px !important;
+}

--- a/navbar.css
+++ b/navbar.css
@@ -68,14 +68,6 @@
   }
 }
 
-.urlbar-input-container {
-  border: none !important;
-}
-
-#urlbar {
-  text-align: center;
-}
-
 :root[tabsintitlebar] #toolbar-menubar[autohide="true"] {
   --tab-min-height: fit-content !important;
   min-height: fit-content !important;

--- a/navbar.css
+++ b/navbar.css
@@ -82,6 +82,11 @@
   padding-top: 3px !important;
 }
 
+#PlacesToolbarItems {
+  display: flex;
+  justify-content: center;
+}
+
 .browser-toolbar {
   &:not(.titlebar-color) {
   background-color: transparent !important;

--- a/urlbar.css
+++ b/urlbar.css
@@ -1,3 +1,7 @@
+#urlbar {
+  text-align: center;
+}
+
 #urlbar-background {
   background-color: transparent !important;
   border: unset !important;


### PR DESCRIPTION
I am not sure exactly how I want this, but this is more of a quick fix to avoid issues with the "navabar" text appearing over elements.