### PR TITLE
feat: add Nix support via home-manager module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728492678,
+        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -16,9 +16,25 @@
         "type": "github"
       }
     },
+    "nur": {
+      "locked": {
+        "lastModified": 1729125404,
+        "narHash": "sha256-2ZtXYNBPi9Ejeb2Heqh+yFTBcstapvtna8Vyl/ugb7w=",
+        "owner": "nix-community",
+        "repo": "NUR",
+        "rev": "7aafd5f0d772efbd2e611c132cc290c3508fe049",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NUR",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nur": "nur"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "A flake that exposes a home-manager module for textfox";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs } @ inputs: let
+    forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux" "x86_64-darwin"];
+    pkgsForEach = nixpkgs.legacyPackages;
+  in {
+    packages = forAllSystems (system: {
+      default = pkgsForEach.${system}.callPackage ./nix/default.nix {};
+    });
+
+    homeManagerModules.default = import ./nix/hm-module.nix inputs;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,9 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nur.url = github:nix-community/NUR;
   };
 
-  outputs = { self, nixpkgs } @ inputs: let
+  outputs = { self, nixpkgs, nur } @ inputs: let
     forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux" "x86_64-darwin"];
     pkgsForEach = nixpkgs.legacyPackages;
   in {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,14 @@
+{stdenv, fetchFromGithub, ...}:
+
+stdenv.mkDerivation {
+  pname = "textfox";
+  version = "git";
+
+  src = ../.;
+
+  installPhase = ''
+    mkdir -p $out/chrome
+    cp -r chrome/* $out/chrome
+    cp user.js $out/user.js  
+  '';
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -4,6 +4,11 @@ let
   inherit (pkgs.stdenv.hostPlatform) system;
   package = inputs.self.packages.${system}.default;
 in {
+
+  imports = [
+    inputs.nur.hmModules.nur
+  ];
+
   options.textfox = {
     enable = lib.mkEnableOption "Enable textfox";
     profile = lib.mkOption {
@@ -17,6 +22,7 @@ in {
       enable = true;
       profiles."${cfg.profile}" = {
           extraConfig = builtins.readFile "${package}/user.js";
+          extensions = [ config.nur.repos.rycee.firefox-addons.sidebery ];
         };
       };
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,28 @@
+inputs: {config, lib, pkgs, ...}:
+let 
+  cfg = config.firefox.textfox;
+  inherit (pkgs.stdenv.hostPlatform) system;
+  package = inputs.self.packages.${system}.default;
+in {
+  options.firefox.textfox = {
+    enable = lib.mkEnableOption "Enable textfox";
+    profile = lib.mkOption {
+      type = lib.types.str;
+      description = "The profile to apply the textfox configuration to";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.firefox = {
+      enable = true;
+      profiles."${cfg.profile}" = {
+          extraConfig = builtins.readFile "${package}/user.js";
+        };
+      };
+
+      home.file.".mozilla/firefox/${cfg.profile}/chrome" = {
+        source = "${package}/chrome";
+        recursive = true;
+      };
+    };
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,10 +1,10 @@
 inputs: {config, lib, pkgs, ...}:
 let 
-  cfg = config.firefox.textfox;
+  cfg = config.textfox;
   inherit (pkgs.stdenv.hostPlatform) system;
   package = inputs.self.packages.${system}.default;
 in {
-  options.firefox.textfox = {
+  options.textfox = {
     enable = lib.mkEnableOption "Enable textfox";
     profile = lib.mkOption {
       type = lib.types.str;

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,94 @@ _a port of spotify tui to firefox_
 > apply the settings in `about:config` manually. These are needed for the css to
 > work.
 
+### Nix
+This repo includes a Nix flake that exposes a home-manager module that installs textfox and sidebery.
+
+To enable the module, add the repo as a flake input, import the module, and enable textfox
+
+If your home-manager module is defined within your `nixosConfigurations`:
+```nix
+# flake.nix
+
+{
+
+    inputs = {
+       # ---Snip---
+       home-manager = {
+         url = "github:nix-community/home-manager";
+         inputs.nixpkgs.follows = "nixpkgs";
+       };
+
+       textfox.url = "github:adriankarlen/textfox";
+       # ---Snip---
+    }
+
+    outputs = {nixpkgs, home-manager, ...} @ inputs: {
+        nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
+          specialArgs = { inherit inputs; };
+          modules = [
+          home-manager.nixosModules.home-manager
+            {
+             # Must pass in inputs so we can access the module
+              home-manager.extraSpecialArgs = {
+                inherit inputs;
+              };
+            }
+         ];
+      };
+   } 
+}
+```
+```nix
+# home.nix
+
+imports = [ inputs.textfox.homeManagerModules.default ];
+
+textfox = {
+    enable = true;
+    profile = "firefox profile name here";
+};
+
+```
+
+
+If you use `home-manager.lib.homeManagerConfiguration`
+```nix
+# flake.nix
+
+    inputs = {
+       # ---Snip---
+       home-manager = {
+         url = "github:nix-community/home-manager";
+         inputs.nixpkgs.follows = "nixpkgs";
+       };
+
+       textfox.url = "github:adriankarlen/textfox";
+       # ---Snip---
+    }
+
+    outputs = {nixpkgs, home-manager, textfox ...}: {
+        homeConfigurations."user@hostname" = home-manager.lib.homeManagerConfiguration {
+         pkgs = nixpkgs.legacyPackages.x86_64-linux;
+
+         modules = [
+            textfox.homeManagerModules.default
+        # ...
+        ];
+     };
+  };
+}
+```
+```nix
+# home.nix
+
+textfox = {
+    enable = true;
+    profile = "firefox profile name here";
+};
+
+```
+
 ### Sidebery
 
 Sidebery css is being set from within `content/sidebery` (applied as content to


### PR DESCRIPTION
Hello, thanks for this awesome theme!

I created a home-manager module for Nix/NixOS users.
I threw this together pretty quickly, so its probably missing some stuff that would be nice, but in terms of just installing the theme it seems to be working

For Nix users, all you have to do is add the repo as a flake input, import the module into home-manager and enable the following settings
```
textfox = {
  enable = true;
  profile = "firefox profile name here"
};
``` 

I couldn't find a way to get the default firefox profile, which is why you have to specify it yourself.
It's also probably possible to install the Sidebery config, but I haven't tried this yet

I haven't updated the README yet with the proper instructions as its getting quite late for me, but I plan to do this so I'll mark this PR as a draft for the time being, but wanted you to be able to go ahead and take a look at it and see if anybody had any improvements that could be made