### PR TITLE
fix: mark #tabbrowser-tabbox margins and paddings to !important

### DIFF
--- a/chrome/browser.css
+++ b/chrome/browser.css
@@ -1,8 +1,8 @@
 #tabbrowser-tabbox {
-  margin: 8px;
+  margin: 8px !important;
   border: var(--border-width) solid var(--border);
   border-radius: var(--rounding);
-  padding: 8px;
+  padding: 8px !important;
   transition: border-color var(--border-transition);
   &:hover {
     color: var(--accent);


### PR DESCRIPTION
Fixed broken margins for Firefox v132.0
<img width="454" alt="image" src="https://github.com/user-attachments/assets/88e95033-876f-4ee7-b61d-b9b017b321de">
