### PR TITLE
feat: expose some configuration options to home manager module

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -15,6 +15,91 @@ in {
       type = lib.types.str;
       description = "The profile to apply the textfox configuration to";
     };
+    config = lib.mkOption {
+      default = {};
+      type = lib.types.submodule {
+        options = {
+          background = lib.mkOption {
+            default = {};
+            type = lib.types.submodule {
+              options = {
+                color = lib.mkOption {
+                  type = lib.types.str;
+                  default = "var(--lwt-accent-color, -moz-dialog)";
+                  description = "Background color of all elements, tab colors derive from this";
+                };
+              };
+            };
+          };
+          displayHorizontalTabs = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Enables horizontal tabs at the top";
+          };
+          font = lib.mkOption {
+            default = {};
+            type = lib.types.submodule {
+              options = {
+                family = lib.mkOption {
+                  type = lib.types.str;
+                  default = "\"SF Mono\", Consolas, monospace";
+                  description = "The font family to use";
+                };
+                size = lib.mkOption {
+                  type = lib.types.str;
+                  default = "14px";
+                  description = "The font size to use";
+                };
+                accent = lib.mkOption {
+                  type = lib.types.str;
+                  default = "var(--toolbarbutton-icon-fill)";
+                  description = "The accent color to use";
+                };
+              };
+            };
+          };
+          border = lib.mkOption {
+            default = {};
+            type = lib.types.submodule {
+              options = {
+                color = lib.mkOption {
+                  type = lib.types.str;
+                  default = "var(--arrowpanel-border-color, --toolbar-field-background-color)";
+                  description = "Border color when not hovered";
+                };
+                transition = lib.mkOption {
+                  type = lib.types.str;
+                  default = "0.2s ease";
+                  description = "Color transitions for borders";
+                };
+                width = lib.mkOption {
+                  type = lib.types.str;
+                  default = "2px";
+                  description = "Width of borders";
+                };
+                radius = lib.mkOption {
+                  type = lib.types.str;
+                  default = "0px";
+                  description = "Border radius used through out the config";
+                };
+              };
+            };
+          };
+          sidebery = lib.mkOption {
+            default = {};
+            type = lib.types.submodule {
+              options = {
+                margin = lib.mkOption {
+                  type = lib.types.str;
+                  default = "0.8rem";
+                  description = "Margin used between elements in sidebery";
+                };
+              };
+            };
+          };
+        };
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -23,12 +108,28 @@ in {
       profiles."${cfg.profile}" = {
           extraConfig = builtins.readFile "${package}/user.js";
           extensions = [ config.nur.repos.rycee.firefox-addons.sidebery ];
-        };
-      };
-
-      home.file.".mozilla/firefox/${cfg.profile}/chrome" = {
-        source = "${package}/chrome";
-        recursive = true;
       };
     };
+
+    home.file.".mozilla/firefox/${cfg.profile}/chrome" = {
+        source = "${package}/chrome";
+        recursive = true;
+    };
+    home.file.".mozilla/firefox/${cfg.profile}/chrome/config.css" = {
+      text = lib.strings.concatStrings [
+        ":root {"
+        ( lib.strings.concatStrings [ " --tf-font-family: " cfg.config.font.family ";" ] )
+        ( lib.strings.concatStrings [ " --tf-font-size: " cfg.config.font.size ";" ] )
+        ( lib.strings.concatStrings [ " --tf-font-accent: " cfg.config.font.accent ";" ] )
+        ( lib.strings.concatStrings [ " --tf-background: " cfg.config.background.color ";" ] )
+        ( lib.strings.concatStrings [ " --tf-border-color: " cfg.config.border.color ";" ] )
+        ( lib.strings.concatStrings [ " --tf-border-transition: " cfg.config.border.transition ";" ] )
+        ( lib.strings.concatStrings [ " --tf-border-width: " cfg.config.border.width ";" ] )
+        ( lib.strings.concatStrings [ " --tf-border-radius: " cfg.config.border.radius ";" ] )
+        ( lib.strings.concatStrings [ " --tf-sidebery-margin: " cfg.config.sidebery.margin ";" ] )
+        ( lib.strings.concatStrings [ " --tf-display-horizontal-tabs: " ( if cfg.config.displayHorizontalTabs then "block" else "none" ) ";" ] )
+        " }"
+      ];
+    };
+  };
 }

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,8 @@ _a port of spotify tui to firefox_
 
 ## Installation
 
+### Manual
+
 1. Download the files
 2. Go to `about:profiles`
 3. Find your profile -- ( _„This is the profile in use and it cannot be deleted.”_ )
@@ -44,44 +46,48 @@ _a port of spotify tui to firefox_
 > work.
 
 ### Nix
+
 This repo includes a Nix flake that exposes a home-manager module that installs textfox and sidebery.
 
-To enable the module, add the repo as a flake input, import the module, and enable textfox
+To enable the module, add the repo as a flake input, import the module, and enable textfox.
 
-If your home-manager module is defined within your `nixosConfigurations`:
+<details><summary>Install using your home-manager module defined within your `nixosConfigurations`:</summary>
+
 ```nix
-# flake.nix
 
-{
+  # flake.nix
 
-    inputs = {
-       # ---Snip---
-       home-manager = {
-         url = "github:nix-community/home-manager";
-         inputs.nixpkgs.follows = "nixpkgs";
-       };
+  {
 
-       textfox.url = "github:adriankarlen/textfox";
-       # ---Snip---
-    }
+      inputs = {
+         # ---Snip---
+         home-manager = {
+           url = "github:nix-community/home-manager";
+           inputs.nixpkgs.follows = "nixpkgs";
+         };
 
-    outputs = {nixpkgs, home-manager, ...} @ inputs: {
-        nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
-          specialArgs = { inherit inputs; };
-          modules = [
-          home-manager.nixosModules.home-manager
-            {
-             # Must pass in inputs so we can access the module
-              home-manager.extraSpecialArgs = {
-                inherit inputs;
-              };
-            }
-         ];
-      };
-   } 
-}
+         textfox.url = "github:adriankarlen/textfox";
+         # ---Snip---
+      }
+
+      outputs = {nixpkgs, home-manager, ...} @ inputs: {
+          nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
+            specialArgs = { inherit inputs; };
+            modules = [
+            home-manager.nixosModules.home-manager
+              {
+               # Must pass in inputs so we can access the module
+                home-manager.extraSpecialArgs = {
+                  inherit inputs;
+                };
+              }
+           ];
+        };
+     } 
+  }
 ```
 ```nix
+
 # home.nix
 
 imports = [ inputs.textfox.homeManagerModules.default ];
@@ -89,15 +95,20 @@ imports = [ inputs.textfox.homeManagerModules.default ];
 textfox = {
     enable = true;
     profile = "firefox profile name here";
+    config = {
+        # Optional config
+    };
 };
-
 ```
+</details>
 
+<details><summary>Install using `home-manager.lib.homeManagerConfiguration`:</summary>
 
-If you use `home-manager.lib.homeManagerConfiguration`
 ```nix
-# flake.nix
 
+  # flake.nix
+
+  {
     inputs = {
        # ---Snip---
        home-manager = {
@@ -111,25 +122,62 @@ If you use `home-manager.lib.homeManagerConfiguration`
 
     outputs = {nixpkgs, home-manager, textfox ...}: {
         homeConfigurations."user@hostname" = home-manager.lib.homeManagerConfiguration {
-         pkgs = nixpkgs.legacyPackages.x86_64-linux;
+            pkgs = nixpkgs.legacyPackages.x86_64-linux;
 
-         modules = [
-            textfox.homeManagerModules.default
-        # ...
-        ];
-     };
+            modules = [
+                textfox.homeManagerModules.default
+                # ...
+            ];
+        };
+    };
+  }
+```
+  ```nix
+
+  # home.nix
+
+  textfox = {
+      enable = true;
+      profile = "firefox profile name here";
+      config = {
+          # Optional config
+      };
   };
-}
-```
+  ```
+</details>
+
+<details><summary>Configuration options:</summary>
+
+All configuration options are optional and can be set as this example shows (real default values [can be found below](#defaults)):
+
 ```nix
-# home.nix
 
-textfox = {
-    enable = true;
-    profile = "firefox profile name here";
-};
-
+  textfox = {
+      enable = true;
+      profile = "firefox profile name here";
+      config = {
+        background = {
+          color = "#123456";
+        };
+        border = {
+          color = "#654321";
+          width = "4px";
+          transition = "1.0s ease";
+          radius = "3px";
+        };
+        displayHorizontalTabs = true;
+        font = { 
+          family = "Fira Code";
+          size = "15px";
+          accent = "#654321";
+        };
+        sidebery = {
+          margin = "1.0rem";
+        };
+      };
+  };
 ```
+</details>
 
 ### Sidebery
 


### PR DESCRIPTION
This is currently more an RFC @adriankarlen and maybe @shadeyg56 .

Since [custom configuration](https://github.com/adriankarlen/textfox/pull/53) is possible, it's easy to adapt the nix home-manager module.

With this PR, it would be possible to configure font family, font size and horizontal tabs, using nix.

**Advantages:**
- Allowing a (nix-)idiomatic usage of textfox
- Much more convenient for home manager users

**Potential challenge:**
- Changes in defaults always have to be taken into account for `hm-module.nix` to preserve the documented behaviour

If you would be willing to merge such a feature @adriankarlen , I can finalize the missing options.
I just don't yet understand all  config options, e.g. `--tf-accent`. I think it would be a good idea to explain these in the README's custom config section,

e.g.

```css
  --tf-rounding: 0px; /*the border radius*/
```