### PR TITLE
fix!: keep the naming convetion the same for all display vars

### DIFF
--- a/chrome/defaults.css
+++ b/chrome/defaults.css
@@ -9,6 +9,6 @@
   --tf-rounding: 0px; /* Border radius used through out the config */
   --tf-margin: 0.8rem; /* Margin used between elements in sidebery */
   --tf-display-horizontal-tabs: none; /* If horizontal tabs should be shown, none = hidden, block = shown */
-  --tf-nav-buttons-display: none; /* If the navigation buttons (back, forward) should be shown, none = hidden, block = shown */
+  --tf-display-nav-buttons: none; /* If the navigation buttons (back, forward) should be shown, none = hidden, block = shown */
   --tf-newtab-logo: "   __            __  ____          \A   / /____  _  __/ /_/ __/___  _  __\A  / __/ _ \\| |/_/ __/ /_/ __ \\| |/_/\A / /_/  __/>  </ /_/ __/ /_/ />  <  \A \\__/\\___/_/|_|\\__/_/  \\____/_/|_|  ";
 }

--- a/chrome/navbar.css
+++ b/chrome/navbar.css
@@ -16,7 +16,7 @@
 /* configurable navigation buttons */
 #back-button,
 #forward-button {
-  display: var(--tf-nav-buttons-display);
+  display: var(--tf-display-nav-buttons);
 }
 
 /* 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -138,7 +138,7 @@ in {
         (lib.strings.concatStrings [ " --tf-border-radius: " cfg.config.border.radius ";" ])
         (lib.strings.concatStrings [ " --tf-sidebery-margin: " cfg.config.sidebery.margin ";" ])
         (lib.strings.concatStrings [ " --tf-display-horizontal-tabs: " (if cfg.config.displayHorizontalTabs then "block" else "none") ";" ])
-        (lib.strings.concatStrings [ " --tf-nav-buttons-display: " (if cfg.config.displayNavButtons then "block" else "none") ";" ])
+        (lib.strings.concatStrings [ " --tf-display-nav-buttons: " (if cfg.config.displayNavButtons then "block" else "none") ";" ])
         (lib.strings.concatStrings [ " --tf-newtab-logo: " cfg.config.newtabLogo ";" ])
         " }"
       ];

--- a/readme.md
+++ b/readme.md
@@ -234,7 +234,7 @@ border radius it would look like this:
   --tf-rounding: 0px; /* Border radius used through out the config */
   --tf-margin: 0.8rem; /* Margin used between elements in sidebery */
   --tf-display-horizontal-tabs: none; /* If horizontal tabs should be shown, none = hidden, block = shown */
-  --tf-nav-buttons-display: none; /* If the navigation buttons (back, forward) should be shown, none = hidden, block = shown */
+  --tf-display-nav-buttons: none; /* If the navigation buttons (back, forward) should be shown, none = hidden, block = shown */
   --tf-newtab-logo: "   __            __  ____          \A   / /____  _  __/ /_/ __/___  _  __\A  / __/ _ \\| |/_/ __/ /_/ __ \\| |/_/\A / /_/  __/>  </ /_/ __/ /_/ />  <  \A \\__/\\___/_/|_|\\__/_/  \\____/_/|_|  ";
 }
 ```


### PR DESCRIPTION
This resolves variable names and breaks the change #62 if you configure navigation buttons to be shown, variable override must be updated.