### PR TITLE
adjusted sidebery.css for pinned tab titles

### DIFF
--- a/chrome/content/sidebery.css
+++ b/chrome/content/sidebery.css
@@ -59,6 +59,12 @@ Styles for Sidebery extension
     height: calc(((100vw - var(--tabs-margin)) / 3.6) / var(--m)) !important;
   }
 
+  /* full-width titles */
+  #root[data-pinned-tabs-list="true"] .PinnedTabsBar .tab-wrapper .Tab {
+    --n: 1 !important;
+    --m: 1.4 !important;
+  }
+
   /* 1 pinned tab */
   .PinnedTabsBar .tab-wrapper:nth-child(1):last-child .Tab {
     --n: 1;


### PR DESCRIPTION
i found your project today and i think it's a really nice design, however i noticed that when i enabled "Show titles of pinned tabs" in sidebery's settings that the tab widths were no longer correct. i thought i'd put this here in case you wanted to upstream it