### PR TITLE
feat: support for native vertical tabs

### DIFF
--- a/chrome/defaults.css
+++ b/chrome/defaults.css
@@ -9,6 +9,6 @@
   --tf-rounding: 0px; /* Border radius used through out the config */
   --tf-margin: 0.8rem; /* Margin used between elements in sidebery */
   --tf-display-horizontal-tabs: none; /* If horizontal tabs should be shown, none = hidden, block = shown */
-  --tf-display-nav-buttons: none; /* If the navigation buttons (back, forward) should be shown, none = hidden, block = shown */
+  --tf-display-nav-buttons: none; /* If the navigation buttons (back, forward) should be shown, none = hidden, flex = shown */
   --tf-newtab-logo: "   __            __  ____          \A   / /____  _  __/ /_/ __/___  _  __\A  / __/ _ \\| |/_/ __/ /_/ __ \\| |/_/\A / /_/  __/>  </ /_/ __/ /_/ />  <  \A \\__/\\___/_/|_|\\__/_/  \\____/_/|_|  ";
 }

--- a/chrome/defaults.css
+++ b/chrome/defaults.css
@@ -10,5 +10,6 @@
   --tf-margin: 0.8rem; /* Margin used between elements in sidebery */
   --tf-display-horizontal-tabs: none; /* If horizontal tabs should be shown, none = hidden, block = shown */
   --tf-display-nav-buttons: none; /* If the navigation buttons (back, forward) should be shown, none = hidden, flex = shown */
+  --tf-display-customize-sidebar: inline-block; /* If the "Customize sidebar" button on the sidebar should be shown, none = hidden, inline-block = shown */ 
   --tf-newtab-logo: "   __            __  ____          \A   / /____  _  __/ /_/ __/___  _  __\A  / __/ _ \\| |/_/ __/ /_/ __ \\| |/_/\A / /_/  __/>  </ /_/ __/ /_/ />  <  \A \\__/\\___/_/|_|\\__/_/  \\____/_/|_|  ";
 }

--- a/chrome/tabs.css
+++ b/chrome/tabs.css
@@ -1,3 +1,31 @@
+#vertical-tabs {
+  margin: 8px !important;
+  border: var(--border-width) solid var(--tf-border);
+  border-radius: var(--tf-rounding);
+  padding: 8px 0px !important;
+  transition: border-color var(--tf-border-transition);
+  &:hover,
+  &:focus {
+    border-color: var(--tf-accent) !important;
+  }
+  &::before {
+    content: "tabs";
+    background-color: var(--tf-bg);
+    position: absolute;
+    margin: -20px 12px;
+    padding: 0 2px;
+    font-size: 1.15em;
+  }
+  &:hover::before {
+    color: var(--tf-accent);
+  }
+}
+
+/* hide customize button from sidebar */
+[view='viewCustomizeSidebar'] {
+  display: none !important;
+}
+
 /* hide window controls */
 .titlebar-buttonbox-container {
   display: none;
@@ -40,9 +68,7 @@
     background-color: var(--tab-hover-background-color) !important;
   }
 }
-.tab-background {
-  background: var(--toolbar-bgcolor) !important;
-}
+
 :root:not([privatebrowsingmode], [firefoxviewhidden])
   :is(toolbarbutton, toolbarpaletteitem)
   + #tabbrowser-tabs,

--- a/chrome/tabs.css
+++ b/chrome/tabs.css
@@ -1,4 +1,4 @@
-#vertical-tabs {
+box#vertical-tabs {
   margin: 8px !important;
   border: var(--border-width) solid var(--tf-border);
   border-radius: var(--tf-rounding);

--- a/chrome/tabs.css
+++ b/chrome/tabs.css
@@ -21,9 +21,9 @@ box#vertical-tabs {
   }
 }
 
-/* hide customize button from sidebar */
+/* configurable sidebar customize button */
 [view='viewCustomizeSidebar'] {
-  display: none !important;
+  display: var(--tf-display-customize-sidebar) !important;
 }
 
 /* hide window controls */

--- a/readme.md
+++ b/readme.md
@@ -235,6 +235,7 @@ border radius it would look like this:
   --tf-margin: 0.8rem; /* Margin used between elements in sidebery */
   --tf-display-horizontal-tabs: none; /* If horizontal tabs should be shown, none = hidden, block = shown */
   --tf-display-nav-buttons: none; /* If the navigation buttons (back, forward) should be shown, none = hidden, block = shown */
+  --tf-display-customize-sidebar: inline-block; /* If the "Customize sidebar" button on the sidebar should be shown, none = hidden, inline-block = shown */ 
   --tf-newtab-logo: "   __            __  ____          \A   / /____  _  __/ /_/ __/___  _  __\A  / __/ _ \\| |/_/ __/ /_/ __ \\| |/_/\A / /_/  __/>  </ /_/ __/ /_/ />  <  \A \\__/\\___/_/|_|\\__/_/  \\____/_/|_|  ";
 }
 ```


### PR DESCRIPTION
Hello, thanks for making this amazing css! 

I've added the tui border around Firefox's native vertical tabs, as mentioned by (#22). I tested it along with the horizontal tabs, and both seem to work fine. However, I did not test with sidebery. 

Also added a config for the "Sidebar customization" button that appears on the sidebar. While doing this I corrected the comment on `--tf-display-nav-buttons`  as its visibility uses `flex` rather than `block`.