### PR TITLE
fix: style entire sidebar revamp

### DIFF
--- a/chrome/defaults.css
+++ b/chrome/defaults.css
@@ -10,6 +10,6 @@
   --tf-margin: 0.8rem; /* Margin used between elements in sidebery */
   --tf-display-horizontal-tabs: none; /* If horizontal tabs should be shown, none = hidden, block = shown */
   --tf-display-nav-buttons: none; /* If the navigation buttons (back, forward) should be shown, none = hidden, flex = shown */
-  --tf-display-customize-sidebar: inline-block; /* If the "Customize sidebar" button on the sidebar should be shown, none = hidden, inline-block = shown */ 
+  --tf-display-sidebar-tools: flex; /* If the "Customize sidebar" button on the sidebar should be shown, none = hidden, flex = shown */ 
   --tf-newtab-logo: "   __            __  ____          \A   / /____  _  __/ /_/ __/___  _  __\A  / __/ _ \\| |/_/ __/ /_/ __ \\| |/_/\A / /_/  __/>  </ /_/ __/ /_/ />  <  \A \\__/\\___/_/|_|\\__/_/  \\____/_/|_|  ";
 }

--- a/chrome/navbar.css
+++ b/chrome/navbar.css
@@ -132,3 +132,9 @@ toolbarbutton.bookmark-item:not(.subviewbutton) {
     margin: -16px 12px;
     left: 0;
   }
+
+  .titlebar-spacer[type="pre-tabs"],
+  .titlebar-spacer[type="post-tabs"] {
+    width: 0 !important;
+  }
+}

--- a/chrome/navbar.css
+++ b/chrome/navbar.css
@@ -70,6 +70,7 @@
     margin: -16px 8px;
     padding: 0 2px;
     font-size: 1.15em;
+    left: 0;
   }
   &:hover::before {
     color: var(--tf-accent);
@@ -125,3 +126,9 @@ toolbarbutton.bookmark-item:not(.subviewbutton) {
     background-color: transparent !important;
   }
 }
+
+@media (-moz-bool-pref: "sidebar.revamp") {
+  #nav-bar::before {
+    margin: -16px 12px;
+    left: 0;
+  }

--- a/chrome/overwrites.css
+++ b/chrome/overwrites.css
@@ -84,4 +84,7 @@
     --identity-tab-color: #ea9a97 !important;
     --identity-icon-color: #ea9a97 !important;
   }
+
+  /* opacity */
+  --inactive-titlebar-opacity: 1 !important;
 }

--- a/chrome/sidebar.css
+++ b/chrome/sidebar.css
@@ -52,6 +52,7 @@
   }
 
   .tools-and-extensions {
+    display: var(--tf-display-sidebar-tools) !important;
     margin: 8px;
     border: var(--border-width) solid var(--tf-border);
     border-radius: var(--tf-rounding) !important;

--- a/chrome/sidebar.css
+++ b/chrome/sidebar.css
@@ -21,7 +21,7 @@
 }
 
 #sidebar {
-  border-radius: var(--tf-rounding);
+  border-radius: var(--tf-rounding) !important;
 }
 
 #sidebar-header {
@@ -30,4 +30,52 @@
 
 #sidebar-splitter {
   display: none;
+}
+
+@media (-moz-bool-pref: "sidebar.revamp") {
+  #sidebar {
+    box-shadow: none !important;
+  }
+  #sidebar-main {
+    :root[lwtheme] & {
+      background-color: var(--tf-bg) !important;
+      background-image: unset !important;
+    }
+  }
+  #sidebar-box {
+    font-size: unset !important;
+    padding: 8px !important;
+    &::before {
+      margin: -20px 4px;
+      content: "tool";
+    }
+  }
+
+  .tools-and-extensions {
+    margin: 8px;
+    border: var(--border-width) solid var(--tf-border);
+    border-radius: var(--tf-rounding) !important;
+    transition: border-color var(--tf-border-transition);
+    &:hover {
+      border-color: var(--tf-accent) !important;
+    }
+    &::before {
+      content: "tools";
+      color: var(--lwt-text-color);
+      background-color: var(--tf-bg);
+      margin: -12px 10px -9px;
+      padding: 0 4px;
+      font-size: 1.15em;
+    }
+    &:hover::before {
+      color: var(--tf-accent);
+    }
+  }
+#tabbrowser-tabs[orient="vertical"] {
+  &:not([expanded]) {
+      #vertical-pinned-tabs-container, .tab-stack {
+        width: 100% !important;
+      }
+    }
+  }
 }

--- a/chrome/tabs.css
+++ b/chrome/tabs.css
@@ -21,11 +21,6 @@ box#vertical-tabs {
   }
 }
 
-/* configurable sidebar customize button */
-[view='viewCustomizeSidebar'] {
-  display: var(--tf-display-customize-sidebar) !important;
-}
-
 /* hide window controls */
 .titlebar-buttonbox-container {
   display: none;

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -41,6 +41,11 @@ in {
             default = false;
             description = "Show back and forward navigation buttons in the Firefox UI";
           };
+          displaySidebarTools = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Show sidebar tools section";
+          };
           newtabLogo = lib.mkOption {
             type = lib.types.str;
             default = "   __            __  ____          \A   / /____  _  __/ /_/ __/___  _  __\A  / __/ _ \\| |/_/ __/ /_/ __ \\| |/_/\A / /_/  __/>  </ /_/ __/ /_/ />  <  \A \\__/\\___/_/|_|\\__/_/  \\____/_/|_|  ";
@@ -138,7 +143,8 @@ in {
         (lib.strings.concatStrings [ " --tf-border-radius: " cfg.config.border.radius ";" ])
         (lib.strings.concatStrings [ " --tf-sidebery-margin: " cfg.config.sidebery.margin ";" ])
         (lib.strings.concatStrings [ " --tf-display-horizontal-tabs: " (if cfg.config.displayHorizontalTabs then "block" else "none") ";" ])
-        (lib.strings.concatStrings [ " --tf-display-nav-buttons: " (if cfg.config.displayNavButtons then "block" else "none") ";" ])
+        (lib.strings.concatStrings [ " --tf-display-nav-buttons: " (if cfg.config.displayNavButtons then "flex" else "none") ";" ])
+        (lib.strings.concatStrings [ " --tf-display-customize-sidebar: " (if cfg.config.displaySidebarTools then "flex" else "none") ";" ])
         (lib.strings.concatStrings [ " --tf-newtab-logo: " cfg.config.newtabLogo ";" ])
         " }"
       ];

--- a/readme.md
+++ b/readme.md
@@ -167,6 +167,7 @@ All configuration options are optional and can be set as this example shows (rea
         };
         displayHorizontalTabs = true;
         displayNavButtons = true;
+        displaySidebarTools  = false;
         newtabLogo = "   __            __  ____          \A   / /____  _  __/ /_/ __/___  _  __\A  / __/ _ \\| |/_/ __/ /_/ __ \\| |/_/\A / /_/  __/>  </ /_/ __/ /_/ />  <  \A \\__/\\___/_/|_|\\__/_/  \\____/_/|_|  ";
         font = { 
           family = "Fira Code";
@@ -234,8 +235,8 @@ border radius it would look like this:
   --tf-rounding: 0px; /* Border radius used through out the config */
   --tf-margin: 0.8rem; /* Margin used between elements in sidebery */
   --tf-display-horizontal-tabs: none; /* If horizontal tabs should be shown, none = hidden, block = shown */
-  --tf-display-nav-buttons: none; /* If the navigation buttons (back, forward) should be shown, none = hidden, block = shown */
-  --tf-display-customize-sidebar: inline-block; /* If the "Customize sidebar" button on the sidebar should be shown, none = hidden, inline-block = shown */ 
+  --tf-display-nav-buttons: none; /* If the navigation buttons (back, forward) should be shown, none = hidden, flex = shown */
+  --tf-display-sidebar-tools: flex; /* If the "Customize sidebar" button on the sidebar should be shown, none = hidden, flex = shown */ 
   --tf-newtab-logo: "   __            __  ____          \A   / /____  _  __/ /_/ __/___  _  __\A  / __/ _ \\| |/_/ __/ /_/ __ \\| |/_/\A / /_/  __/>  </ /_/ __/ /_/ />  <  \A \\__/\\___/_/|_|\\__/_/  \\____/_/|_|  ";
 }
 ```


### PR DESCRIPTION
This PR extends upon #79 by adding a box for the tools and extensions and updating the box title for when the tools is opened to "tool" instead of "tabs" (since this was previously used by sidebery.

Added some other minor fixes to the titlebar and navbar that popped up when enabling the flag.

Resolves #22 

Preview:
<img width="1251" alt="Screenshot 2025-01-01 at 13 22 57" src="https://github.com/user-attachments/assets/adebd9e2-fac6-4b92-a647-19afddead5b6" />

