### PR TITLE
Nix: fix broken attribute in hm-module

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -56,7 +56,7 @@ in {
             default = true;
             description = "Show sidebar tools section";
           };
-          displayTitles = lib.mkoption {
+          displayTitles = lib.mkOption {
             type = lib.types.bool;
             default = true;
             description = "Show titles on blocks";


### PR DESCRIPTION
Hi, this fixes a single character error in hm-module.nix that was keeping my config from building

changed `lib.mkoption` to `lib.mkOption`