### PR TITLE
Support aarch64-darwin as a target

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   outputs = { self, nixpkgs, nur } @ inputs: let
-    forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux" "x86_64-darwin"];
+    forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
     pkgsForEach = nixpkgs.legacyPackages;
   in {
     packages = forAllSystems (system: {

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -3,6 +3,10 @@ let
   cfg = config.textfox;
   inherit (pkgs.stdenv.hostPlatform) system;
   package = inputs.self.packages.${system}.default;
+  configDir =
+    if pkgs.stdenv.hostPlatform.isDarwin
+    then "Library/Application\ Support/Firefox/Profiles/"
+    else ".mozilla/firefox/";
 in {
 
   imports = [
@@ -141,11 +145,11 @@ in {
       };
     };
 
-    home.file.".mozilla/firefox/${cfg.profile}/chrome" = {
+    home.file."${configDir}${cfg.profile}/chrome" = {
       source = "${package}/chrome";
       recursive = true;
     };
-    home.file.".mozilla/firefox/${cfg.profile}/chrome/config.css" = {
+    home.file."${configDir}${cfg.profile}/chrome/config.css" = {
       text = lib.strings.concatStrings [
         ":root {"
         (lib.strings.concatStrings [ " --tf-font-family: " cfg.config.font.family ";" ])


### PR DESCRIPTION
This PR
* Adds "aarch64-darwin" as an output system
* Sets the profiles directory based on host platform, so that chroma files are correctly placed in `~/Library/Application Support/Firefox/Profiles/<profile>/chroma` on Mac OS.

Running this locally now on Mac OS without issues. Though you might be interested in merging if it doesn't break anything on your end, seeing that it's such an unintrusive change that enables mac users to install textfox via home manager. :)