### PR TITLE
fix: home-manager module rewriting firefox's userChrome setting

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -142,6 +142,7 @@ in {
       profiles."${cfg.profile}" = {
         extraConfig = builtins.readFile "${package}/user.js";
         extensions = [ config.nur.repos.rycee.firefox-addons.sidebery ];
+        containersForce = true;
         userChrome = lib.mkBefore (builtins.readFile "${package}/chrome/userChrome.css");
       };
     };

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -142,11 +142,16 @@ in {
       profiles."${cfg.profile}" = {
         extraConfig = builtins.readFile "${package}/user.js";
         extensions = [ config.nur.repos.rycee.firefox-addons.sidebery ];
+        userChrome = lib.mkBefore (builtins.readFile "${package}/chrome/userChrome.css");
       };
     };
 
     home.file."${configDir}${cfg.profile}/chrome" = {
-      source = "${package}/chrome";
+      source = pkgs.lib.cleanSourceWith {
+        src = "${package}/chrome";
+        filter = path: type:
+          !(type == "regular" && baseNameOf path == "userChrome.css");
+      };
       recursive = true;
     };
     home.file."${configDir}${cfg.profile}/chrome/config.css" = {


### PR DESCRIPTION
Might be better to import firefox's config using a @import instead, but this just appends the firefox config onto the end of the userChrome.css

fixes #106