### PR TITLE
Add sidebar collapsing functionality

### DIFF
--- a/chrome/content/sidebery.css
+++ b/chrome/content/sidebery.css
@@ -127,10 +127,15 @@ Styles for Sidebery extension
     }
   }
 
+  #root.root:not(:hover) .Tab .title {
+    opacity: var(--tf-sidebar-collapsed-title);
+  }
+
   .Tab .body {
     text-transform: lowercase;
     & .title {
       color: color-mix(in hsl, var(--s-popup-fg) 50%, transparent) !important;
+      transition: opacity var(--tf-sidebar-transition) !important;
     }
   }
 

--- a/chrome/defaults.css
+++ b/chrome/defaults.css
@@ -3,6 +3,10 @@
   --tf-font-size: 14px; /* Font size of config */
   --tf-accent: var(--toolbarbutton-icon-fill); /* Accent color used, eg: color when hovering a container  */
   --tf-bg: var(--lwt-accent-color, -moz-dialog); /* Background color of all elements, tab colors derive from this */
+  --tf-sidebar-active: 18rem; /* Width of the sidebar (sidebery) while being hovered over */
+  --tf-sidebar-collapsed: 18rem; /* Width of the sidebar while not being hovered over */
+  --tf-sidebar-collapsed-title: 100; /* Opacity of tab titles while the sidebar is not being hovered over */
+  --tf-sidebar-transition: 0.2s ease; /* Transition of the width of the sidebar between mouse movement */
   --tf-border: var(--arrowpanel-border-color, --toolbar-field-background-color); /* Border color when not hovered */
   --tf-border-transition: 0.2s ease; /* Smooth color transitions for borders */
   --tf-border-width: 2px; /* Width of borders */

--- a/chrome/sidebar.css
+++ b/chrome/sidebar.css
@@ -2,10 +2,14 @@
   margin: 8px;
   border: var(--border-width) solid var(--tf-border);
   border-radius: var(--tf-rounding) !important;
-  transition: border-color var(--tf-border-transition);
+  transition: width var(--tf-sidebar-transition), border-color var(--tf-border-transition);
   background: var(--tf-bg) !important;
+  min-width: 0px !important;
+  max-width: none !important;
+  width: var(--tf-sidebar-collapsed) !important;
   &:hover {
     border-color: var(--tf-accent) !important;
+    width: var(--tf-sidebar-active) !important;
   }
   &::before {
     display: var(--tf-display-titles);


### PR DESCRIPTION
This adds the ability to change some functionality in terms of "collapsing" the side bar when it's not hovering in order to save a lot of screen space. These changes might be against the spirit of the style of the project in the sense that dynamic content isn't reminiscent of a TUI.

Because of that I made the default of the introduced variables to leave the behavior as-is and leave it up to the user to change it in their config. I think this is a very commonly made edit for sidebery so it might make sense to introduce here, I also would've liked to introduce an edit to center favicons when the tab titles are hidden and collapsed but I don't know how to do that in a clean way while keeping it toggleable.