### PR TITLE
fix(navbar): remove list-style-image instead of hiding icon

### DIFF
--- a/chrome/navbar.css
+++ b/chrome/navbar.css
@@ -26,13 +26,15 @@
 */
 #identity-box[pageproxystate="valid"] {
   &.verifiedDomain {
-    #identity-icon,
     #identity-permission-box:not([hasSharingIcon]),
     #permissions-granted-icon {
       display: var(--tf-display-urlbar-icons) !important;
     }
     #permissions-granted-icon + box:has(image[sharing="true"]) {
       margin-left: -4px;
+    }
+    #identity-icon {
+      list-style-image: unset !important;
     }
   }
   &.mixedActiveBlocked {


### PR DESCRIPTION
For some reason unbeknownst to man the bookmarking menu uses the #identity-icon id.

When this icon is hidden, the bookmarking popup is also hidden, this resolves this issue by removing the icon image instead.

Actually resolves #77 