### PR TITLE
Use the grayscale filter for the toolbarbutton icons

### DIFF
--- a/chrome/defaults.css
+++ b/chrome/defaults.css
@@ -15,4 +15,5 @@
   --tf-display-sidebar-tools: flex; /* If the "Customize sidebar" button on the sidebar should be shown, none = hidden, flex = shown */ 
   --tf-display-titles: flex; /* If titles (tabs, navbar, main etc.) should be shown, none = hidden, flex = shown */
   --tf-newtab-logo: "   __            __  ____          \A   / /____  _  __/ /_/ __/___  _  __\A  / __/ _ \\| |/_/ __/ /_/ __ \\| |/_/\A / /_/  __/>  </ /_/ __/ /_/ />  <  \A \\__/\\___/_/|_|\\__/_/  \\____/_/|_|  ";
+  --tf-extension-icons-color-filter: none; /* Set a filter on icons in the toolbar and context menu */
 }

--- a/chrome/icons.css
+++ b/chrome/icons.css
@@ -29,218 +29,26 @@
 }
 
 /*
- * ─[ MONOCHROME EXTENSIONS - Monochrome icons for some extensions ]───────
+ * ─[ EXTENSION ICON COLOR FILTER ]───────
 */
 
-@media (-moz-bool-pref: "shyfox.enable.ext.mono.toolbar.icons") {
-  /* Userchrome Toggle => sidebar icon */
-  :is(.webextension-browser-action, .eom-addon-button):is(
-      [data-extensionid="userchrome-toggle-extended@n2ezr.ru"]
-    )
-    .toolbarbutton-icon {
-    list-style-image: url("./icons/command-frames.svg");
-  }
+/* .toolbarbutton-icon { */
+toolbarbutton, toolbaritem {
+  filter: var(--tf-extension-icons-color-filter);
+}
 
-  /* uBlock Origin => custom svg icon */
-  :is(
-      .webextension-browser-action,
-      .eom-addon-button
-    )[data-extensionid="uBlock0@raymondhill.net"]
-    .toolbarbutton-icon {
-    list-style-image: url("./icons/ublock.svg");
-  }
-
-  /* Bitwarden => custom svg icon */
-  :is(
-      .webextension-browser-action,
-      .eom-addon-button
-    )[data-extensionid="{446900e4-71c2-419f-a6a7-df9c091e268b}"]
-    .toolbarbutton-icon {
-    list-style-image: url("./icons/bitwarden.svg");
-  }
-  button[title="Bitwarden"] img {
-    content: url("./icons/bitwarden.svg");
-  }
-
-  /* Privacy Badger => it's own monochrome icon */
-  :is(
-      .webextension-browser-action,
-      .eom-addon-button
-    )[data-extensionid="jid1-MnnxcxisBPnSXQ@jetpack"]
-    .toolbarbutton-icon {
-    list-style-image: url("./icons/PrivacyBadger.svg");
-    scale: 1.3;
-  }
-
-  /* Dark Reader => custom svg icon (moon) */
-  :is(
-      .webextension-browser-action,
-      .eom-addon-button
-    )[data-extensionid="addon@darkreader.org"]
-    .toolbarbutton-icon {
-    list-style-image: url("./icons/moon.svg");
-  }
-
-  /* Video Download Helper => custom svg icon */
-  :is(
-      .webextension-browser-action,
-      .eom-addon-button
-    )[data-extensionid="{b9db16a4-6edc-47ec-a1f4-b86292ed211d}"]
-    .toolbarbutton-icon {
-    list-style-image: url("./icons/video-download-helper.svg");
-  }
-
-  /* Auto Tab Discard => power icon */
-  :is(
-      .webextension-browser-action,
-      .eom-addon-button
-    )[data-extensionid="{c2c003ee-bd69-42a2-b0e9-6f34222cb046}"]
-    .toolbarbutton-icon {
-    list-style-image: url("./icons/quit.svg");
-  }
-
-  /* Midnight Lizard => custom svg icon */
-  :is(
-      .webextension-browser-action,
-      .eom-addon-button
-    )[data-extensionid="{8fbc7259-8015-4172-9af1-20e1edfbbd3a}"]
-    .toolbarbutton-icon {
-    list-style-image: url("./icons/midnight-lizard.svg");
-    scale: 1.3;
-  }
-
-  /* Vimium => custom svg icon */
-  :is(
-      .webextension-browser-action,
-      .eom-addon-button
-    )[data-extensionid="{d7742d87-e61d-4b78-b8a1-b469842139fa}"]
-    .toolbarbutton-icon {
-    list-style-image: url("./icons/vimium.svg");
-  }
-
-  /* Stylus => custom svg icon */
-  :is(
-      .webextension-browser-action,
-      .eom-addon-button
-    )[data-extensionid="{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d}"]
-    .toolbarbutton-icon {
-    list-style-image: url("./icons/stylus.svg");
-  }
-
-  /* Containers => custom svg icon */
-  :is(
-      .webextension-browser-action,
-      .eom-addon-button
-    )[data-extensionid="@testpilot-containers"]
-    .toolbarbutton-icon {
-    list-style-image: url("./icons/container.svg");
-  }
-
-  /* hide all toolbutton badges*/
-  .toolbarbutton-badge {
-    display: none;
-  }
+/* hide all toolbutton badges*/
+.toolbarbutton-badge {
+  display: none;
 }
 
 /* context menu */
-
-@media (-moz-bool-pref: "shyfox.enable.ext.mono.context.icons") {
-  #contentAreaContextMenu,
-  #toolbar-context-menu,
-  #unified-extensions-context-menu {
-    /* ublock */
-    menuitem[id*="ublock0_raymondhill_net-menuitem-_uBlock0-"] {
-      .menu-iconic-icon {
-        opacity: 0 !important;
-      }
-      background-image: url("./icons/ublock.svg") !important;
-    }
-
-    /* simple translate */
-    :is(menu, menuitem):not(menu *)[id*="simple-translate_sienori-menuitem-"] {
-      .menu-iconic-icon {
-        opacity: 0 !important;
-      }
-      background-image: url("./icons/translate.svg") !important;
-    }
-
-    /* bitwarden */
-    #_446900e4-71c2-419f-a6a7-df9c091e268b_-menuitem-_root {
-      .menu-iconic-icon {
-        opacity: 0 !important;
-      }
-      background-image: url("./icons/bitwarden.svg") !important;
-      & > menupopup {
-        & > *[id*="-menuitem-_autofill"] {
-          background-image: url("chrome://browser/skin/login.svg") !important;
-        }
-        & > *[id*="-menuitem-_copy-username"] {
-          background-image: url("./icons/edit-copy.svg") !important;
-        }
-        & > *[id*="-menuitem-_copy-password"] {
-          background-image: url("./icons/password.svg") !important;
-        }
-
-        & > *[id*="-menuitem-_autofill-identity"] {
-          background-image: url("chrome://browser/skin/fxa/avatar-empty.svg") !important;
-        }
-        & > *[id*="-menuitem-_autofill-card"] {
-          background-image: url("./icons/credit-card.svg") !important;
-        }
-
-        & > *[id*="-menuitem-_generate-password"] {
-          background-image: url("./icons/reload-auto.svg") !important;
-        }
-        & > *[id*="-menuitem-_copy-identifier"] {
-          background-image: url("./icons/edit-copy.svg") !important;
-        }
-
-        *[id*="_create-"] {
-          background-image: url("chrome://global/skin/icons/plus.svg") !important;
-        }
-      }
-    }
-
-    /* clean url */
-    #_74145f27-f039-47ce-a470-a662b129930a_-menuitem-_copy-link-to-clipboard {
-      .menu-iconic-icon {
-        opacity: 0 !important;
-      }
-      background-image: url("./icons/eraser.svg") !important;
-    }
-  }
-
-  /* video download helper */
-  #_b9db16a4-6edc-47ec-a1f4-b86292ed211d_-menuitem-_vdh-top {
-    .menu-iconic-icon {
-      opacity: 0 !important;
-    }
-    background-image: url("./icons/video-download-helper.svg") !important;
-  }
-
-  /* sidebar switcher bitwarden icon */
-  #sidebarswitcher_menu__446900e4-71c2-419f-a6a7-df9c091e268b_-sidebar-action {
-    .menu-iconic-icon {
-      opacity: 0 !important;
-    }
-    background-image: url("./icons/bitwarden.svg") !important;
-  }
-  #sidebar-switcher-target[style*="fde67d36-ff48-49e7-8ec4-3cf26deea141"]
-    #sidebar-icon {
-    list-style-image: url("./icons/bitwarden.svg") !important;
-  }
-}
-
-/* Video Download Helper */
-#sidebarswitcher_menu__b9db16a4-6edc-47ec-a1f4-b86292ed211d_-sidebar-action {
+#contentAreaContextMenu,
+#toolbar-context-menu,
+#unified-extensions-context-menu {
   .menu-iconic-icon {
-    opacity: 0 !important;
+    filter: var(--tf-extension-icons-color-filter);
   }
-  background-image: url("./icons/video-download-helper.svg") !important;
-}
-#sidebar-switcher-target[style*="89b69b2a-5ae9-4b43-addc-4bf789f8448f"]
-  #sidebar-icon {
-  list-style-image: url("./icons/video-download-helper.svg") !important;
 }
 
 /*

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -61,8 +61,6 @@ in {
       preferences = let
         icons = config.textfox.config.icons;
       in ''
-        pref("shyfox.enable.ext.mono.toolbar.icons", ${boolToString icons.toolbar.extensions.enable});
-        pref("shyfox.enable.ext.mono.context.icons", ${boolToString icons.context.extensions.enable});
         pref("shyfox.enable.context.menu.icons", ${boolToString icons.context.firefox.enable});
       '';
 

--- a/readme.md
+++ b/readme.md
@@ -220,11 +220,9 @@ settings provided.
 ## Customization
 
 The icon configuration utilizes code that is originally from ShyFox, therefore
-the same settings are used (these can be set in about:config).
+the same setting is used (can be set in about:config).
 | Setting | true | false (default) |
 | -------------------------------------- | --------------------------------------------------------------------- | ------------------------- |
-| `shyfox.enable.ext.mono.toolbar.icons` | Supported extensions get monochrome icons as toolbar buttons | Standard icons used |
-| `shyfox.enable.ext.mono.context.icons` | Supported extensions get monochrome icons as context menu items | Standard icons used |
 | `shyfox.enable.context.menu.icons` | Many context menu items get icons | No icons in context menus |
 
 ### CSS configurations
@@ -259,6 +257,7 @@ border radius it would look like this:
   --tf-display-titles: flex; /* If titles (tabs, navbar, main etc.) should be shown, none = hidden, flex = shown */
   --tf-newtab-logo: "   __            __  ____          \A   / /____  _  __/ /_/ __/___  _  __\A  / __/ _ \\| |/_/ __/ /_/ __ \\| |/_/\A / /_/  __/>  </ /_/ __/ /_/ />  <  \A \\__/\\___/_/|_|\\__/_/  \\____/_/|_|  ";
 }
+  --tf-extension-icons-color-filter: none; /* Set a filter on icons in the toolbar and context menu */
 ```
 
 ### Changing the new tab logo


### PR DESCRIPTION
The current solution for monochrome icons works by putting a monochrome version of each icon into textfox. This has the disadvantage that there will always be icons missing. I had the idea to instead use [the CSS grayscale filter](https://developer.mozilla.org/en-US/docs/Web/CSS/filter-function/grayscale) for it, and it works really well:

![Screenshot From 2025-02-11 10-27-55](https://github.com/user-attachments/assets/0cac8df7-9898-413b-8f8f-d26468174f92)

