### PR TITLE
Make the context menu readable

### DIFF
--- a/chrome/menus.css
+++ b/chrome/menus.css
@@ -17,16 +17,6 @@ slot[part="content"] {
   }
 }
 
-menu,
-menuitem {
-  &:where([_moz-menuactive]:not([disabled="true"])) {
-    background: var(--tab-selected-bgcolor) !important;
-  }
-  &:where([_moz-menuactive="true"][disabled="true"]) {
-    background: var(--tab-hover-background-color) !important;
-  }
-}
-
 .menupopup-arrowscrollbox {
   border-width: var(--border-width) !important;
 }


### PR DESCRIPTION
While working on my other PR (no, I have not forgotten about it :smiley:), I noticed a bug in Textfox. In the default configuration, you can't read the hovered text in context menus (the item below "Save Page as..." is hovered):
![the hovered item is not visible](https://github.com/user-attachments/assets/e5583f6e-3c6f-4500-8214-0a715be4c226)

This is due to `menu` using `--tab-selected-bgcolor` and `menuitem` using `--tab-hover-background-color`. When reverting this, they are readable:

![The item is visible](https://github.com/user-attachments/assets/6fa59006-ec75-4069-9184-51927d55d7ec)

