### PR TITLE
feat: Add support for librewolf also

### DIFF
--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -1,5 +1,5 @@
-inputs: {config, lib, pkgs, ...}:
-let 
+inputs: { config, lib, pkgs, ... }:
+let
   inherit (pkgs.stdenv.hostPlatform) system;
   package = inputs.self.packages.${system}.default;
   configDir =
@@ -7,8 +7,24 @@ let
     then "Library/Application\ Support/Firefox/Profiles/"
     else ".mozilla/firefox/";
 
+  configDirLibreWolf =
+    if pkgs.stdenv.hostPlatform.isDarwin
+    then "Library/Application\ Support/LibreWolf/Profiles/"
+    else ".librewolf/";
+
   cfg = config.textfox;
-in {
+
+  cfgFirefox = {
+    enable = true;
+    profiles."${cfg.profile}" = {
+      extraConfig = builtins.readFile "${package}/user.js";
+      extensions = [ config.nur.repos.rycee.firefox-addons.sidebery ];
+      containersForce = true;
+      userChrome = lib.mkBefore (builtins.readFile "${package}/chrome/userChrome.css");
+    };
+  };
+in
+{
 
   imports = [
     inputs.nur.hmModules.nur
@@ -21,29 +37,30 @@ in {
       type = lib.types.str;
       description = "The profile to apply the textfox configuration to";
     };
+    librewolf = lib.mkEnableOption "Enable LibreWolf browser configuration";
   };
 
   config = lib.mkIf cfg.enable {
-    programs.firefox = {
-      enable = true;
-      profiles."${cfg.profile}" = {
-        extraConfig = builtins.readFile "${package}/user.js";
-        extensions = [ config.nur.repos.rycee.firefox-addons.sidebery ];
-        containersForce = true;
-        userChrome = lib.mkBefore (builtins.readFile "${package}/chrome/userChrome.css");
-      };
-    };
+    programs.firefox = cfgFirefox;
+    programs.librewolf = cfgFirefox // { enable = lib.mkDefault cfg.librewolf; };
 
-    home.file."${configDir}${cfg.profile}/chrome" = {
-      source = pkgs.lib.cleanSourceWith {
-        src = "${package}/chrome";
-        filter = path: type:
-          !(type == "regular" && baseNameOf path == "userChrome.css");
+    home.file =
+      let
+        chrome = {
+          source = pkgs.lib.cleanSourceWith {
+            src = "${package}/chrome";
+            filter = path: type:
+              !(type == "regular" && baseNameOf path == "userChrome.css");
+          };
+          recursive = true;
+        };
+      in
+      {
+        "${configDir}${cfg.profile}/chrome" = chrome;
+        "${configDirLibreWolf}${cfg.profile}/chrome" = chrome;
+
+        "${configDir}${cfg.profile}/chrome/config.css".text = cfg.configCss;
+        "${configDirLibreWolf}${cfg.profile}/chrome/config.css".text = cfg.configCss;
       };
-      recursive = true;
-    };
-    home.file."${configDir}${cfg.profile}/chrome/config.css" = {
-      text = cfg.configCss;
-    };
   };
 }


### PR DESCRIPTION
LibreWolf is a Firefox fork that has gained popularity following recent changes to Firefox's Terms of Service.

This update introduces LibreWolf as an optional entry for TextFox. If a user has `programs.librewolf.enable = true;` enabled alongside TextFox, the theme will now be applied to LibreWolf as well. Also textfox exposes option to enable librewolf.


>[!Note]
> I have not updated the `readme.md` would like to have the pr first reviewed and discuss how this can be added in readme?