### PR TITLE
Fixed evaluation warning by adding packages to firefox.extensions

### DIFF
--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -28,7 +28,7 @@ in {
       enable = true;
       profiles."${cfg.profile}" = {
         extraConfig = builtins.readFile "${package}/user.js";
-        extensions = [ config.nur.repos.rycee.firefox-addons.sidebery ];
+        extensions.packages = [ config.nur.repos.rycee.firefox-addons.sidebery ];
         containersForce = true;
         userChrome = lib.mkBefore (builtins.readFile "${package}/chrome/userChrome.css");
       };


### PR DESCRIPTION
When rebuilding my system, I would get this evaluation warning:
![20250311_07h20m37s_grim](https://github.com/user-attachments/assets/6aef9393-103b-450d-b29d-7436aac55463)
Adding `.packages` at the end of the `extensions` declaration seemed to fix the issue.