### PR TITLE
revert: fix extension declaration

### DIFF
--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -28,7 +28,7 @@ in {
       enable = true;
       profiles."${cfg.profile}" = {
         extraConfig = builtins.readFile "${package}/user.js";
-        extensions.packages = [ config.nur.repos.rycee.firefox-addons.sidebery ];
+        extensions = [ config.nur.repos.rycee.firefox-addons.sidebery ];
         containersForce = true;
         userChrome = lib.mkBefore (builtins.readFile "${package}/chrome/userChrome.css");
       };


### PR DESCRIPTION
Commit c49cd64 for PR #123  by @Antisune101 breaks home-manager uasge for me:

```
       error: A definition for option `programs.firefox.profiles.convenient.extensions' is not of type `list of package'. Definition values:
       - In `/nix/store/ly02k47f5y4h98gn86xwzwbxizpa25yd-source/collections/_/firefox.nix':
           {
             packages = [
               <derivation sidebery-5.2.0>
             ];
           }
```

Before merging this PR it would probably good to know where problems come from.
I am using  the latest stable home-manager and nixpkgs version `24.11`.

@Antisune101 Since I am guessing that our home-manager versions differ, can you share what you are using?

In case this is really the underlying problem, @adriankarlen it might be nexcessary to think about which home-manager version should be supported.