### PR TITLE
feat: Add support for "legacy" extension configuration

### DIFF
--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -21,6 +21,11 @@ in {
       type = lib.types.str;
       description = "The profile to apply the textfox configuration to";
     };
+    useLegacyExtensions = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      decription = "If 'extensions' should be used instead of 'extensions.packages' for extension config";
+    };
   };
 
   config = lib.mkIf cfg.enable {

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -28,7 +28,7 @@ in {
       enable = true;
       profiles."${cfg.profile}" = {
         extraConfig = builtins.readFile "${package}/user.js";
-        extensions = [ config.nur.repos.rycee.firefox-addons.sidebery ];
+        extensions.packages = [ config.nur.repos.rycee.firefox-addons.sidebery ];
         containersForce = true;
         userChrome = lib.mkBefore (builtins.readFile "${package}/chrome/userChrome.css");
       };

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -6,6 +6,7 @@ let
     if pkgs.stdenv.hostPlatform.isDarwin
     then "Library/Application\ Support/Firefox/Profiles/"
     else ".mozilla/firefox/";
+  extensionList = [ config.nur.repos.rycee.firefox-addons.sidebery ];
 
   cfg = config.textfox;
 in {
@@ -24,7 +25,7 @@ in {
     useLegacyExtensions = lib.mkOption {
       type = lib.types.bool;
       default = false;
-      decription = "If 'extensions' should be used instead of 'extensions.packages' for extension config";
+      description = "If 'extensions' should be used instead of 'extensions.packages' for extension config";
     };
   };
 
@@ -33,10 +34,13 @@ in {
       enable = true;
       profiles."${cfg.profile}" = {
         extraConfig = builtins.readFile "${package}/user.js";
-        extensions.packages = [ config.nur.repos.rycee.firefox-addons.sidebery ];
         containersForce = true;
         userChrome = lib.mkBefore (builtins.readFile "${package}/chrome/userChrome.css");
-      };
+      } // (
+        if cfg.useLegacyExtensions
+        then { extensions = extensionList; }
+        else { extensions.packages = extensionList; }
+      );
     };
 
     home.file."${configDir}${cfg.profile}/chrome" = {

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -24,7 +24,7 @@ in {
     };
     useLegacyExtensions = lib.mkOption {
       type = lib.types.bool;
-      default = false;
+      default = true;
       description = "If 'extensions' should be used instead of 'extensions.packages' for extension config";
     };
   };


### PR DESCRIPTION
This should hopefully be a more permanent fix to #123 breaking home-manager config on some versions. 

I've declared a `useLegacyExtensions` option that when enabled configures extensions with just `extensions` instead of `extensions.packages`. Users using a version of home manager newer than  nix-community/home-manager#6389 can set this to false to get rid of the warning.

It seems to be working on my system, but I haven't been able to test it on a system using that's using home-manager `24.11`. 

@snaeil , could you perhaps test it on your system to see if everything is working?
