### PR TITLE
fix(nix): add missing semicolon

### DIFF
--- a/nix/modules/options.nix
+++ b/nix/modules/options.nix
@@ -116,7 +116,7 @@ in {
         type = str;
         default = "none";
         description = "Text transform to use";
-      }
+      };
     };
 
     configCss = mkOption {


### PR DESCRIPTION
Fix nix build, missing semicolon meant the build would hit a syntax error.