### PR TITLE
fix!: default useLegacyExtensions to false

### DIFF
--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -20,7 +20,7 @@ in {
     };
     useLegacyExtensions = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = false;
       description = "If 'extensions' should be used instead of 'extensions.packages' for extension config";
     };
   };


### PR DESCRIPTION
There's no reason to expect people to be running legacy home-manager by default.