### PR TITLE
Clipped tab icons

### DIFF
--- a/chrome/tabs.css
+++ b/chrome/tabs.css
@@ -14,7 +14,7 @@ box#vertical-tabs {
     content: "tabs";
     background-color: var(--tf-bg);
     position: absolute;
-    margin: -1.75rem .75rem;
+    margin: -1.75rem .4rem;
     padding: 0 2px;
   }
   &:hover::before {


### PR DESCRIPTION
Fixes styling issues for newer versions of Firefox as seen in issue #157 
Before:
<img width="375" height="682" alt="image" src="https://github.com/user-attachments/assets/7c4ca70e-1751-4d08-9277-892411d4c63d" />

After:
<img width="390" height="391" alt="image" src="https://github.com/user-attachments/assets/9ff846d4-f69b-4134-8674-7c0108bba8c1" />
