### PR TITLE
fix(nix): Remove a anti-pattern string escape

### DIFF
--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -10,7 +10,7 @@ let
   package = inputs.self.packages.${system}.default;
   configDir =
     if pkgs.stdenv.hostPlatform.isDarwin then
-      "Library/Application\ Support/Firefox/Profiles/"
+      "Library/Application Support/Firefox/Profiles/"
     else
       ".mozilla/firefox/";
 


### PR DESCRIPTION
This fixes a warn introduced by Lix 2.95, as outlined [here](https://docs.lix.systems/manual/lix/stable/contributing/deprecated-features.html#dp-feature-broken-string-escape). Nix handles a lot of string manipulation in a way that's not what people typically expect, and as a result this escape does nothing