### PR TITLE
fix(nix): Handle XDG spec compliance for home-manager installations

### DIFF
--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -9,10 +9,8 @@ let
   inherit (pkgs.stdenv.hostPlatform) system;
   package = inputs.self.packages.${system}.default;
   configDir =
-    if pkgs.stdenv.hostPlatform.isDarwin then
-      "Library/Application Support/Firefox/Profiles/"
-    else
-      ".mozilla/firefox/";
+    "${config.programs.firefox.configPath}/"
+    + (lib.optionalString pkgs.stdenv.hostPlatform.isDarwin "Profiles/");
 
   cfg = config.textfox;
 in


### PR DESCRIPTION
Home-manager 26.05 now uses the XDG_CONFIG_HOME to store the Firefox profiles. This patch addresses the change. More info here https://github.com/nix-community/home-manager/commit/b869d6cadbc6c0d9135799b8ee31fc7275cab225