### PR TITLE
fix(nix): Mirrow upstream border css changes

### DIFF
--- a/nix/modules/options.nix
+++ b/nix/modules/options.nix
@@ -84,7 +84,7 @@ in
       border = {
         color = mkOption {
           type = str;
-          default = "var(--arrowpanel-border-color, --toolbar-field-background-color)";
+          default = "var(--panel-border-color, --toolbar-field-background-color)";
           description = "Border color when not hovered";
         };
         transition = mkOption {

--- a/readme.md
+++ b/readme.md
@@ -261,7 +261,7 @@ The theme ships with a `defaults.css`, this file can be overridden by creating a
   --tf-font-size: 14px; /* Font size of config */
   --tf-accent: var(--toolbarbutton-icon-fill); /* Accent color used, eg: color when hovering a container  */
   --tf-bg: var(--lwt-accent-color, -moz-dialog); /* Background color of all elements, tab colors derive from this */
-  --tf-border: var(--arrowpanel-border-color, --toolbar-field-background-color); /* Border color when not hovered */
+  --tf-border: var(--panel-border-color, --toolbar-field-background-color); /* Border color when not hovered */
   --tf-border-transition: 0.2s ease; /* Smooth color transitions for borders */
   --tf-border-width: 2px; /* Width of borders */
   --tf-rounding: 0px; /* Border radius used through out the config */


### PR DESCRIPTION
Food for thought later: the defaults could be imported from the css file, so separate changes aren't necessary