### PR TITLE
fix: adjust selectors to work with newer versions

### DIFF
--- a/chrome/navbar.css
+++ b/chrome/navbar.css
@@ -9,7 +9,7 @@
 #translations-button-icon,
 #tracking-protection-icon-container,
 #star-button-box,
-.urlbar-page-action:not([hidden="true"]) {
+.urlbar-page-action:not([hidden]) {
   display: var(--tf-display-urlbar-icons);
 }
 

--- a/chrome/urlbar.css
+++ b/chrome/urlbar.css
@@ -2,7 +2,7 @@
   text-align: center;
 }
 
-#urlbar-background {
+#urlbar-background, .urlbar-background {
   background-color: transparent !important;
   border: unset !important;
   box-shadow: unset !important;


### PR DESCRIPTION
In the version of Firefox I'm using (151.0.4), `urlbar-background` is now a class and not an id. I left the id for backward compatibility.

Also, for URL buttons, the attribute is just plain `hidden`, not `hidden="true"`.