### PR TITLE
fix(sidebar): Set better sidebar label margins

### DIFF
--- a/chrome/sidebar.css
+++ b/chrome/sidebar.css
@@ -66,7 +66,7 @@
     content: "tools";
     color: var(--lwt-text-color);
     background-color: var(--tf-bg);
-    margin: 3.25rem .4rem;
+    margin: -1.10rem 0.40rem 2.75rem 0.3rem;
     padding: 0 4px;
   }
   &:hover::before {


### PR DESCRIPTION
Based on local testing, this should improve the "Tools" label in both standard, and vertical tab styles (both expanded and collapsed). 

Previously, the standard mode would be missing the label entirely, and vertical tabs would display them in the wrong place.

Only minor issue is that the label is not horizontally centered very well across different display DPIs, but I can't offer a better solution at this time