### PR TITLE
chore(nix): change nixpkgs source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Firefox theme for the tui enthusiast";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.zst";
   };
 
   outputs =


### PR DESCRIPTION
It is recommended to not use github as source for nixpkgs but instead use the project hosted channel tarballs, as described here:

https://discourse.nixos.org/t/psa-use-nixos-org-tarballs-for-your-flake-inputs/79950

Resons given are reduced download sizes, not having problems with guthub rate limiting and others.